### PR TITLE
Compatibility changes for Angstrom / Node 0.8

### DIFF
--- a/src/pru.cpp
+++ b/src/pru.cpp
@@ -228,7 +228,7 @@ Handle<Value> waitForInterrupt(const Arguments& args) {
     baton->request.data = baton;
     baton->callback = Persistent<Function>::New(callback);
 	
-	uv_queue_work(uv_default_loop(), &baton->request, AsyncWork, AsyncAfter);
+	uv_queue_work(uv_default_loop(), &baton->request, AsyncWork, (uv_after_work_cb)AsyncAfter);
 	return scope.Close(Undefined());
 }
 
@@ -257,7 +257,7 @@ Handle<Value> forceExit(const Arguments& args) {
 };
 
 /* Initialise the module */
-void Init(Handle<Object> exports, Handle<Object> module) {
+void Init(Handle<Object> exports) {
 	//	pru.init();
 	exports->Set(String::NewSymbol("init"), FunctionTemplate::New(InitPRU)->GetFunction());
 	


### PR DESCRIPTION
Angstrom for Beaglebone Black is still at version 0.8.22 of node.js.  I had to make a few changes to build node-pru.  These follow the guidelines from https://github.com/joyent/node/wiki/Api-changes-between-v0.8-and-v0.10 and should be compatible with 0.10.
- add explicit cast to (uv_after_work_cb) to 4th arg of call to uv_queue_work
- use backwards-compatible version of Init, that doesn't receive a handle to module
