### PR TITLE
Fix am335x_pru_package library function changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 examples/*.bin
+.idea/

--- a/examples/overlay/enable_pru_input.sh
+++ b/examples/overlay/enable_pru_input.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+if ! id | grep -q root; then
+    echo "must be run as root"
+    exit
+fi
+
+cd `dirname $0`
+if  cat /sys/devices/bone_capemgr.*/slots |grep PRU || false ; then
+    cat /sys/devices/bone_capemgr.*/slots
+    exit
+else
+    dtc -O dtb -o PRU-INPUT-00A0.dtbo -b 0 -@ pru_input_overlay.dts
+    mv PRU-INPUT-00A0.dtbo /lib/firmware/
+    echo PRU-INPUT:00A0 > /sys/devices/bone_capemgr.*/slots
+    cat /sys/devices/bone_capemgr.*/slots
+    exit
+fi

--- a/examples/overlay/enable_pru_output.sh
+++ b/examples/overlay/enable_pru_output.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+if ! id | grep -q root; then
+    echo "must be run as root"
+    exit
+fi
+
+cd `dirname $0`
+if  cat /sys/devices/bone_capemgr.*/slots |grep PRU || false ; then
+    cat /sys/devices/bone_capemgr.*/slots
+    exit
+else
+    dtc -O dtb -o PRU-OUTPUT-00A0.dtbo -b 0 -@ pru_output_overlay.dts
+    mv PRU-OUTPUT-00A0.dtbo /lib/firmware/
+    echo PRU-OUTPUT:00A0 > /sys/devices/bone_capemgr.*/slots
+    cat /sys/devices/bone_capemgr.*/slots
+    exit
+fi

--- a/examples/overlay/pru_input_overlay.dts
+++ b/examples/overlay/pru_input_overlay.dts
@@ -1,0 +1,41 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+    compatible = "ti,beaglebone", "ti,beaglebone-black";
+
+	/* identification */
+	part-number = "PRU-PARALLEL";
+
+	/* version */
+	version = "00A0";
+
+	fragment@0 {
+		target = <&am33xx_pinmux>;
+		__overlay__ {
+			pruicss_pins: pinmux_pruicss_pins {
+				pinctrl-single,pins = <
+					0x190 0x26 // PRU0 R31[0]
+					0x194 0x26 // PRU0 R31[1]
+					0x198 0x26 // PRU0 R31[2]
+					0x19C 0x26 // PRU0 R31[3]
+					0x1A0 0x26 // PRU0 R31[4]
+					0x1A4 0x26 // PRU0 R31[5]
+					0x1A8 0x26 // PRU0 R31[6]
+					0x1AC 0x26 // PRU0 R31[7]
+					0x038 0x26 // PRU0 R31[14]
+					0x1B4 0x25 // PRU0 R31[16]
+				>;
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&pruss>;
+		__overlay__{
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <&pruicss_pins>;
+		};
+	};
+};

--- a/examples/overlay/pru_output_overlay.dts
+++ b/examples/overlay/pru_output_overlay.dts
@@ -1,0 +1,37 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+    compatible = "ti,beaglebone", "ti,beaglebone-black";
+
+	/* identification */
+	part-number = "PRU-PARALLEL";
+
+	/* version */
+	version = "00A0";
+
+	fragment@0 {
+		target = <&am33xx_pinmux>;
+		__overlay__ {
+			pruicss_pins: pinmux_pruicss_pins {
+            		pinctrl-single,pins = <
+            			0x190 0x05	/* P9_31 to PRU output */
+            			0x194 0x05	/* P9_29 to PRU output */
+            			0x198 0x05	/* P9_30 to PRU output */
+            			0x19C 0x05	/* P9_28 to PRU output */
+            			0x1A4 0x05	/* P9_27 to PRU output */
+            			0x1AC 0x05	/* P9_25 to PRU output */
+            			>;
+            };
+		};
+	};
+
+	fragment@2 {
+		target = <&pruss>;
+		__overlay__{
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <&pruicss_pins>;
+		};
+	};
+};

--- a/src/pru.cpp
+++ b/src/pru.cpp
@@ -237,7 +237,7 @@ Handle<Value> waitForInterrupt(const Arguments& args) {
 /* Clear Interrupt */
 Handle<Value> clearInterrupt(const Arguments& args) {
 	HandleScope scope;
-	prussdrv_pru_clear_event(PRU0_ARM_INTERRUPT);
+	prussdrv_pru_clear_event(PRU_EVTOUT_0, PRU0_ARM_INTERRUPT);
 	return scope.Close(Undefined());
 };
 


### PR DESCRIPTION
Added PRU overlays
Added Scripts of enabling overlays
Eddited README for information on overlays

am335x_pru_package changed prussdrv_pru_clear_event and they applied the patch so its no longer needed when pulling from master.
